### PR TITLE
token过期重新换取token后reloadData的支持

### DIFF
--- a/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.h
+++ b/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.h
@@ -38,6 +38,9 @@
 - (NSInteger)loadData;
 + (NSInteger)loadDataWithParams:(NSDictionary * _Nullable)params success:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))successCallback fail:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))failCallback;
 
+// reload
+- (NSInteger)reloadData;
+
 // cancel
 - (void)cancelAllRequests;
 - (void)cancelRequestWithRequestId:(NSInteger)requestID;

--- a/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
+++ b/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
@@ -29,6 +29,7 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
 
 @property (nonatomic, readwrite) CTAPIManagerErrorType errorType;
 @property (nonatomic, strong) NSMutableArray *requestIdList;
+@property (nonatomic, copy) NSDictionary *params;
 
 @property (nonatomic, strong, nullable) void (^successBlock)(CTAPIBaseManager *apimanager);
 @property (nonatomic, strong, nullable) void (^failBlock)(CTAPIBaseManager *apimanager);
@@ -103,8 +104,8 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
 #pragma mark - calling api
 - (NSInteger)loadData
 {
-    NSDictionary *params = [self.paramSource paramsForApi:self];
-    NSInteger requestId = [self loadDataWithParams:params];
+    self.params = [self.paramSource paramsForApi:self];
+    NSInteger requestId = [self loadDataWithParams:self.params];
     return requestId;
 }
 
@@ -115,10 +116,15 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
 
 - (NSInteger)loadDataWithParams:(NSDictionary *)params success:(void (^)(CTAPIBaseManager *))successCallback fail:(void (^)(CTAPIBaseManager *))failCallback
 {
+    self.params = params;
     self.successBlock = successCallback;
     self.failBlock = failCallback;
 
     return [self loadDataWithParams:params];
+}
+
+- (NSInteger)reloadData {
+    return [self loadDataWithParams:self.params];
 }
 
 - (NSInteger)loadDataWithParams:(NSDictionary *)params


### PR DESCRIPTION
框架中对token过期或者非法的情况有处理，而且发出了一个通知，通知将当前API作为参数带出
[[NSNotificationCenter defaultCenter] postNotificationName:kCTUserTokenIllegalNotification
                                                                object:nil
                                                              userInfo:@{
kCTUserTokenNotificationUserInfoKeyManagerToContinue:self
                                                                         }];

kCTUserTokenNotificationUserInfoKeyManagerToContinue看参数的命名字可知是token更换后，可以重新发起之前的请求的意思，但是这里拿到的self其实无法完全满足重发的需求。

如果当前API是使用loadData方法发起的，在通知接收方法中取到API实例重新loadData就可以了。但是如果当前API的发起是通过类方法+ (NSInteger)loadDataWithParams:(NSDictionary * _Nullable)params success发起的，像重新发起的时候就会发现缺少params，当前API实例也没有保存params，所以这种情况下无法在脱离当时的业务场景的情况下独立重新发起请求。

所以我尝试着做了一些修改，试图解决这个问题，以完善框架对重新发起请求的支持，你看下是否可行