### PR TITLE
demo响应报文处理代码崩溃

### DIFF
--- a/CTNetworking/Demo/DemoService/DemoService.m
+++ b/CTNetworking/Demo/DemoService/DemoService.m
@@ -46,9 +46,19 @@
 - (NSDictionary *)resultWithResponseData:(NSData *)responseData response:(NSURLResponse *)response request:(NSURLRequest *)request error:(NSError **)error
 {
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
+    if (responseData == nil) {
+        return result;
+    }
+    
     result[kCTApiProxyValidateResultKeyResponseData] = responseData;
-    result[kCTApiProxyValidateResultKeyResponseJSONString] = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
-    result[kCTApiProxyValidateResultKeyResponseJSONObject] = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:NULL];
+    if ([responseData isKindOfClass:[NSData class]]) {
+        result[kCTApiProxyValidateResultKeyResponseJSONString] = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
+        result[kCTApiProxyValidateResultKeyResponseJSONObject] = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:NULL];
+    } else {
+        result[kCTApiProxyValidateResultKeyResponseJSONString] = responseData;
+        result[kCTApiProxyValidateResultKeyResponseJSONObject] = responseData;
+    }
+    
     return result;
 }
 


### PR DESCRIPTION
方法
- (NSDictionary *)resultWithResponseData:(NSData *)responseData
                                response:(NSURLResponse *)response
                                 request:(NSURLRequest *)request
                                   error:(NSError **)error;
中响应报文数据responseData，类型为NSDictionary，导致崩溃

加了一些类型判断和容错的代码