### PR TITLE
报文处理相关代码优化修改

### DIFF
--- a/CTNetworking/CTNetworking/CTNetworkingDefines.h
+++ b/CTNetworking/CTNetworking/CTNetworkingDefines.h
@@ -56,9 +56,9 @@ extern NSString * _Nonnull const kCTUserTokenIllegalNotification;
 extern NSString * _Nonnull const kCTUserTokenNotificationUserInfoKeyManagerToContinue;
 
 // result
-extern NSString * _Nonnull const kCTApiProxyValidateResultKeyResponseJSONObject;
-extern NSString * _Nonnull const kCTApiProxyValidateResultKeyResponseJSONString;
-extern NSString * _Nonnull const kCTApiProxyValidateResultKeyResponseData;
+extern NSString * _Nonnull const kCTApiProxyValidateResultKeyResponseObject;
+extern NSString * _Nonnull const kCTApiProxyValidateResultKeyResponseString;
+//extern NSString * _Nonnull const kCTApiProxyValidateResultKeyResponseData;
 
 /*************************************************************************************/
 @protocol CTAPIManager <NSObject>

--- a/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.m
+++ b/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.m
@@ -18,9 +18,9 @@
 static NSString * const kAXApiProxyDispatchItemKeyCallbackSuccess = @"kAXApiProxyDispatchItemCallbackSuccess";
 static NSString * const kAXApiProxyDispatchItemKeyCallbackFail = @"kAXApiProxyDispatchItemCallbackFail";
 
-NSString * const kCTApiProxyValidateResultKeyResponseJSONObject = @"kCTApiProxyValidateResultKeyResponseJSONObject";
-NSString * const kCTApiProxyValidateResultKeyResponseJSONString = @"kCTApiProxyValidateResultKeyResponseJSONString";
-NSString * const kCTApiProxyValidateResultKeyResponseData = @"kCTApiProxyValidateResultKeyResponseData";
+NSString * const kCTApiProxyValidateResultKeyResponseObject = @"kCTApiProxyValidateResultKeyResponseObject";
+NSString * const kCTApiProxyValidateResultKeyResponseString = @"kCTApiProxyValidateResultKeyResponseString";
+//NSString * const kCTApiProxyValidateResultKeyResponseData = @"kCTApiProxyValidateResultKeyResponseData";
 
 @interface CTApiProxy ()
 
@@ -85,21 +85,21 @@ NSString * const kCTApiProxyValidateResultKeyResponseData = @"kCTApiProxyValidat
     dataTask = [[self sessionManagerWithService:request.service] dataTaskWithRequest:request
                                          uploadProgress:nil
                                        downloadProgress:nil
-                                      completionHandler:^(NSURLResponse * _Nonnull response, NSData * _Nullable responseData, NSError * _Nullable error) {
+                                      completionHandler:^(NSURLResponse * _Nonnull response, id _Nullable responseObject, NSError * _Nullable error) {
         NSNumber *requestID = @([dataTask taskIdentifier]);
         [self.dispatchTable removeObjectForKey:requestID];
         
-        NSDictionary *result = [request.service resultWithResponseData:responseData response:response request:request error:&error];
+        NSDictionary *result = [request.service resultWithResponseObject:responseObject response:response request:request error:&error];
         // 输出返回数据
-        CTURLResponse *CTResponse = [[CTURLResponse alloc] initWithResponseString:result[kCTApiProxyValidateResultKeyResponseJSONString]
+        CTURLResponse *CTResponse = [[CTURLResponse alloc] initWithResponseString:result[kCTApiProxyValidateResultKeyResponseString]
                                                                         requestId:requestID
                                                                           request:request
-                                                                  responseContent:result[kCTApiProxyValidateResultKeyResponseJSONObject]
+                                                                  responseObject:result[kCTApiProxyValidateResultKeyResponseObject]
                                                                             error:error];
 
         CTResponse.logString = [CTLogger logDebugInfoWithResponse:(NSHTTPURLResponse *)response
-                                                  rawResponseData:responseData
-                                                   responseString:result[kCTApiProxyValidateResultKeyResponseJSONString]
+                                                   responseObject:responseObject
+                                                   responseString:result[kCTApiProxyValidateResultKeyResponseString]
                                                           request:request
                                                             error:error];
 

--- a/CTNetworking/CTNetworking/Components/BaseAPITarget/H5API/Target_H5API.m
+++ b/CTNetworking/CTNetworking/Components/BaseAPITarget/H5API/Target_H5API.m
@@ -63,8 +63,8 @@ NSString * const kCTOriginActionCallbackKeyProgress = @"progress";
     if (successCallback) {
         NSMutableDictionary *fetchedData = [manager fetchDataWithReformer:nil];
         if ([fetchedData isKindOfClass:[NSMutableDictionary class]]) {
-            [fetchedData removeObjectForKey:kCTApiProxyValidateResultKeyResponseJSONString];
-            [fetchedData removeObjectForKey:kCTApiProxyValidateResultKeyResponseData];
+            [fetchedData removeObjectForKey:kCTApiProxyValidateResultKeyResponseString];
+//            [fetchedData removeObjectForKey:kCTApiProxyValidateResultKeyResponseData];
         }
         successCallback(fetchedData);
     }

--- a/CTNetworking/CTNetworking/Components/LogComponents/CTLogger.h
+++ b/CTNetworking/CTNetworking/Components/LogComponents/CTLogger.h
@@ -14,7 +14,7 @@
 @interface CTLogger : NSObject
 
 + (NSString *)logDebugInfoWithRequest:(NSURLRequest *)request apiName:(NSString *)apiName service:(id <CTServiceProtocol>)service;
-+ (NSString *)logDebugInfoWithResponse:(NSHTTPURLResponse *)response rawResponseData:(NSData *)rawResponseData responseString:(NSString *)responseString request:(NSURLRequest *)request error:(NSError *)error;
++ (NSString *)logDebugInfoWithResponse:(NSHTTPURLResponse *)response responseObject:(id)responseObject responseString:(NSString *)responseString request:(NSURLRequest *)request error:(NSError *)error;
 + (NSString *)logDebugInfoWithCachedResponse:(CTURLResponse *)response methodName:(NSString *)methodName service:(id <CTServiceProtocol>)service params:(NSDictionary *)params;
 
 @end

--- a/CTNetworking/CTNetworking/Components/LogComponents/CTLogger.m
+++ b/CTNetworking/CTNetworking/Components/LogComponents/CTLogger.m
@@ -59,7 +59,7 @@
     return logString;
 }
 
-+ (NSString *)logDebugInfoWithResponse:(NSHTTPURLResponse *)response rawResponseData:(NSData *)rawResponseData responseString:(NSString *)responseString request:(NSURLRequest *)request error:(NSError *)error
++ (NSString *)logDebugInfoWithResponse:(NSHTTPURLResponse *)response responseObject:(id)responseObject responseString:(NSString *)responseString request:(NSURLRequest *)request error:(NSError *)error
 {
     NSMutableString *logString = nil;
 #ifdef DEBUG
@@ -75,7 +75,11 @@
     [logString appendFormat:@"Content:\n\t%@\n\n", responseString];
     [logString appendFormat:@"Request URL:\n\t%@\n\n", request.URL];
     [logString appendFormat:@"Request Data:\n\t%@\n\n",request.originRequestParams.CT_jsonString];
-    [logString appendFormat:@"Raw Response String:\n\t%@\n\n", [[NSString alloc] initWithData:rawResponseData encoding:NSUTF8StringEncoding]];
+    if ([responseObject isKindOfClass:[NSData class]]) {
+        [logString appendFormat:@"Raw Response String:\n\t%@\n\n", [[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding]];
+    } else {
+        [logString appendFormat:@"Raw Response String:\n\t%@\n\n", responseObject];
+    }
     [logString appendFormat:@"Raw Response Header:\n\t%@\n\n", response.allHeaderFields];
     if (isSuccess == NO) {
         [logString appendFormat:@"Error Domain:\t\t\t\t\t\t\t%@\n", error.domain];

--- a/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.h
+++ b/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.h
@@ -20,7 +20,7 @@ typedef NS_ENUM(NSUInteger, CTURLResponseStatus)
 
 @property (nonatomic, assign, readonly) CTURLResponseStatus status;
 @property (nonatomic, copy, readonly) NSString *contentString;
-@property (nonatomic, copy, readonly) NSDictionary *content;
+@property (nonatomic, copy, readonly) id content;
 @property (nonatomic, assign, readonly) NSInteger requestId;
 @property (nonatomic, copy, readonly) NSURLRequest *request;
 @property (nonatomic, copy, readonly) NSData *responseData;
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, CTURLResponseStatus)
 
 @property (nonatomic, assign, readonly) BOOL isCache;
 
-- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSNumber *)requestId request:(NSURLRequest *)request responseContent:(NSDictionary *)responseContent error:(NSError *)error;
+- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSNumber *)requestId request:(NSURLRequest *)request responseObject:(id)responseObject error:(NSError *)error;
 
 // 使用initWithData的response，它的isCache是YES，上面两个函数生成的response的isCache是NO
 - (instancetype)initWithData:(NSData *)data;

--- a/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.m
+++ b/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.m
@@ -26,7 +26,7 @@
 @implementation CTURLResponse
 
 #pragma mark - life cycle
-- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSNumber *)requestId request:(NSURLRequest *)request responseContent:(NSDictionary *)responseContent error:(NSError *)error
+- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSNumber *)requestId request:(NSURLRequest *)request responseObject:(NSDictionary *)responseObject error:(NSError *)error
 {
     self = [super init];
     if (self) {
@@ -37,7 +37,7 @@
         self.originRequestParams = request.originRequestParams;
         self.isCache = NO;
         self.status = [self responseStatusWithError:error];
-        self.content = responseContent ? responseContent : @{};
+        self.content = responseObject ? responseObject : @{};
         self.errorMessage = [NSString stringWithFormat:@"%@", error];
     }
     return self;

--- a/CTNetworking/CTNetworking/Services/CTServiceProtocol.h
+++ b/CTNetworking/CTNetworking/Services/CTServiceProtocol.h
@@ -18,7 +18,7 @@
                          methodName:(NSString *)methodName
                         requestType:(CTAPIManagerRequestType)requestType;
 
-- (NSDictionary *)resultWithResponseData:(NSData *)responseData
+- (NSDictionary *)resultWithResponseObject:(id)responseObject
                                 response:(NSURLResponse *)response
                                  request:(NSURLRequest *)request
                                    error:(NSError **)error;

--- a/CTNetworking/Demo/DemoService/DemoService.m
+++ b/CTNetworking/Demo/DemoService/DemoService.m
@@ -43,20 +43,20 @@
     return nil;
 }
 
-- (NSDictionary *)resultWithResponseData:(NSData *)responseData response:(NSURLResponse *)response request:(NSURLRequest *)request error:(NSError **)error
+- (NSDictionary *)resultWithResponseObject:(id)responseObject response:(NSURLResponse *)response request:(NSURLRequest *)request error:(NSError **)error
 {
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
-    if (responseData == nil) {
+    if (error || !responseObject) {
         return result;
     }
     
-    result[kCTApiProxyValidateResultKeyResponseData] = responseData;
-    if ([responseData isKindOfClass:[NSData class]]) {
-        result[kCTApiProxyValidateResultKeyResponseJSONString] = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
-        result[kCTApiProxyValidateResultKeyResponseJSONObject] = [NSJSONSerialization JSONObjectWithData:responseData options:0 error:NULL];
+    if ([responseObject isKindOfClass:[NSData class]]) {
+        result[kCTApiProxyValidateResultKeyResponseString] = [[NSString alloc] initWithData:responseObject encoding:NSUTF8StringEncoding];
+        result[kCTApiProxyValidateResultKeyResponseObject] = [NSJSONSerialization JSONObjectWithData:responseObject options:0 error:NULL];
     } else {
-        result[kCTApiProxyValidateResultKeyResponseJSONString] = responseData;
-        result[kCTApiProxyValidateResultKeyResponseJSONObject] = responseData;
+        //这里的kCTApiProxyValidateResultKeyResponseString是用作打印日志用的，实际使用时可以把实际类型的对象转换成string用于日志打印
+//        result[kCTApiProxyValidateResultKeyResponseString] = responseObject;
+        result[kCTApiProxyValidateResultKeyResponseObject] = responseObject;
     }
     
     return result;


### PR DESCRIPTION
由于CTApiProxy中dataTaskWithRequest返回的数据类型不可知，所以相应的修改了一些方法和参数的类型命名