### PR TITLE
DemoService中判断条件if (error || !responseObject)错误的问题

### DIFF
--- a/CTNetworking/Demo/DemoService/DemoService.m
+++ b/CTNetworking/Demo/DemoService/DemoService.m
@@ -46,7 +46,7 @@
 - (NSDictionary *)resultWithResponseObject:(id)responseObject response:(NSURLResponse *)response request:(NSURLRequest *)request error:(NSError **)error
 {
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
-    if (error || !responseObject) {
+    if (*error || !responseObject) {
         return result;
     }
     


### PR DESCRIPTION
…e:(NSURLResponse *)response request:(NSURLRequest *)request error:(NSError **)error

方法在传入**的时候，判断条件    if (error || !responseObject) 中的error应该改为*error 作为判断条件，否者会直接返回空的result