### PR TITLE
开放loadDataWithParams实例方法

### DIFF
--- a/CTNetworking.xcodeproj/project.pbxproj
+++ b/CTNetworking.xcodeproj/project.pbxproj
@@ -239,8 +239,8 @@
 		4A1E17A02045585A00BDBF7B /* BaseAPIManager */ = {
 			isa = PBXGroup;
 			children = (
-				4A1E17A12045585A00BDBF7B /* CTAPIBaseManager.m */,
 				4A1E17A22045585A00BDBF7B /* CTAPIBaseManager.h */,
+				4A1E17A12045585A00BDBF7B /* CTAPIBaseManager.m */,
 			);
 			path = BaseAPIManager;
 			sourceTree = "<group>";

--- a/CTNetworking/CTNetworking/CTNetworkingDefines.h
+++ b/CTNetworking/CTNetworking/CTNetworkingDefines.h
@@ -71,7 +71,7 @@ extern NSString * _Nonnull const kCTApiProxyValidateResultKeyResponseString;
 @optional
 - (void)cleanData;
 - (NSDictionary *_Nullable)reformParams:(NSDictionary *_Nullable)params;
-- (NSInteger)loadDataWithParams:(NSDictionary *_Nullable)params;
+- (NSString *_Nonnull)loadDataWithParams:(NSDictionary *_Nullable)params;
 
 @end
 

--- a/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.h
+++ b/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.h
@@ -20,4 +20,6 @@ typedef void(^CTCallback)(CTURLResponse *response);
 - (void)cancelRequestWithRequestID:(NSString *)requestID;
 - (void)cancelRequestWithRequestIDList:(NSArray *)requestIDList;
 
+- (void)cancelAllRequests;
+
 @end

--- a/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.h
+++ b/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.h
@@ -16,8 +16,8 @@ typedef void(^CTCallback)(CTURLResponse *response);
 
 + (instancetype)sharedInstance;
 
-- (NSNumber *)callApiWithRequest:(NSURLRequest *)request success:(CTCallback)success fail:(CTCallback)fail;
-- (void)cancelRequestWithRequestID:(NSNumber *)requestID;
+- (NSString *)callApiWithRequest:(NSURLRequest *)request success:(CTCallback)success fail:(CTCallback)fail;
+- (void)cancelRequestWithRequestID:(NSString *)requestID;
 - (void)cancelRequestWithRequestIDList:(NSArray *)requestIDList;
 
 @end

--- a/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.m
+++ b/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.m
@@ -83,6 +83,21 @@ NSString * const kCTApiProxyValidateResultKeyResponseString = @"kCTApiProxyValid
 }
 
 #pragma mark - public methods
+
+- (void)cancelAllRequests
+{
+    pthread_rwlock_wrlock(&_dispatchTableLock);
+    
+    [self.dispatchTable enumerateKeysAndObjectsUsingBlock:^(id  _Nonnull key,
+                                                            NSURLSessionDataTask * _Nonnull obj,
+                                                            BOOL * _Nonnull stop) {
+        [obj cancel];
+    }];
+    [self.dispatchTable removeAllObjects];
+    
+    pthread_rwlock_unlock(&_dispatchTableLock);
+}
+
 - (void)cancelRequestWithRequestID:(NSString *)requestID
 {
     pthread_rwlock_wrlock(&_dispatchTableLock);

--- a/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.m
+++ b/CTNetworking/CTNetworking/Components/APIProxy/CTApiProxy.m
@@ -44,6 +44,10 @@ NSString * const kCTApiProxyValidateResultKeyResponseString = @"kCTApiProxyValid
     return self;
 }
 
+- (void)dealloc {
+    pthread_rwlock_destroy(&_dispatchTableLock);
+}
+
 #pragma mark - getters and setters
 - (NSMutableDictionary *)dispatchTable
 {

--- a/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.h
+++ b/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.h
@@ -36,6 +36,7 @@
 
 // start
 - (NSInteger)loadData;
+- (NSInteger)loadDataWithParams:(NSDictionary * _Nullable)params success:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))successCallback fail:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))failCallback;
 + (NSInteger)loadDataWithParams:(NSDictionary * _Nullable)params success:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))successCallback fail:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))failCallback;
 
 // cancel

--- a/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.h
+++ b/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.h
@@ -35,13 +35,13 @@
 @property (nonatomic, assign, readonly) BOOL isLoading;
 
 // start
-- (NSInteger)loadData;
-- (NSInteger)loadDataWithParams:(NSDictionary * _Nullable)params success:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))successCallback fail:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))failCallback;
-+ (NSInteger)loadDataWithParams:(NSDictionary * _Nullable)params success:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))successCallback fail:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))failCallback;
+- (NSString *_Nonnull)loadData;
+- (NSString *_Nonnull)loadDataWithParams:(NSDictionary * _Nullable)params success:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))successCallback fail:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))failCallback;
++ (NSString *_Nonnull)loadDataWithParams:(NSDictionary * _Nullable)params success:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))successCallback fail:(void (^ _Nullable)(CTAPIBaseManager * _Nonnull apiManager))failCallback;
 
 // cancel
 - (void)cancelAllRequests;
-- (void)cancelRequestWithRequestId:(NSInteger)requestID;
+- (void)cancelRequestWithRequestId:(NSString *_Nonnull)requestID;
 
 // finish
 - (id _Nullable )fetchDataWithReformer:(id <CTAPIManagerDataReformer> _Nullable)reformer;

--- a/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
+++ b/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
@@ -77,6 +77,8 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
 {
     [self cancelAllRequests];
     _requestIdList = nil;
+    
+    pthread_rwlock_destroy(&_requestIdListLock);
 }
 
 #pragma mark - NSCopying

--- a/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
+++ b/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
@@ -407,6 +407,10 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
 #pragma mark - private methods
 - (void)removeRequestIdWithRequestID:(NSString *)requestId
 {
+    if (![requestId isKindOfClass:[NSString class]]) {
+        return;
+    }
+    
     NSString *requestIDToRemove = nil;
     for (NSString *storedRequestId in self.requestIdList) {
         if ([storedRequestId isEqualToString:requestId]) {

--- a/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
+++ b/CTNetworking/CTNetworking/Components/BaseAPIManager/CTAPIBaseManager.m
@@ -84,10 +84,10 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
     [self.requestIdList removeAllObjects];
 }
 
-- (void)cancelRequestWithRequestId:(NSInteger)requestID
+- (void)cancelRequestWithRequestId:(NSString *)requestID
 {
     [self removeRequestIdWithRequestID:requestID];
-    [[CTApiProxy sharedInstance] cancelRequestWithRequestID:@(requestID)];
+    [[CTApiProxy sharedInstance] cancelRequestWithRequestID:requestID];
 }
 
 - (id)fetchDataWithReformer:(id<CTAPIManagerDataReformer>)reformer
@@ -102,19 +102,19 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
 }
 
 #pragma mark - calling api
-- (NSInteger)loadData
+- (NSString *)loadData
 {
     NSDictionary *params = [self.paramSource paramsForApi:self];
-    NSInteger requestId = [self loadDataWithParams:params];
+    NSString *requestId = [self loadDataWithParams:params];
     return requestId;
 }
 
-+ (NSInteger)loadDataWithParams:(NSDictionary *)params success:(void (^)(CTAPIBaseManager *))successCallback fail:(void (^)(CTAPIBaseManager *))failCallback
++ (NSString *)loadDataWithParams:(NSDictionary *)params success:(void (^)(CTAPIBaseManager *))successCallback fail:(void (^)(CTAPIBaseManager *))failCallback
 {
     return [[[self alloc] init] loadDataWithParams:params success:successCallback fail:failCallback];
 }
 
-- (NSInteger)loadDataWithParams:(NSDictionary *)params success:(void (^)(CTAPIBaseManager *))successCallback fail:(void (^)(CTAPIBaseManager *))failCallback
+- (NSString *)loadDataWithParams:(NSDictionary *)params success:(void (^)(CTAPIBaseManager *))successCallback fail:(void (^)(CTAPIBaseManager *))failCallback
 {
     self.successBlock = successCallback;
     self.failBlock = failCallback;
@@ -122,9 +122,9 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
     return [self loadDataWithParams:params];
 }
 
-- (NSInteger)loadDataWithParams:(NSDictionary *)params
+- (NSString *)loadDataWithParams:(NSDictionary *)params
 {
-    NSInteger requestId = 0;
+    NSString *requestId = @"";
     NSDictionary *reformedParams = [self reformParams:params];
     if (reformedParams == nil) {
         reformedParams = @{};
@@ -158,7 +158,7 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
                 request.service = service;
                 [CTLogger logDebugInfoWithRequest:request apiName:self.child.methodName service:service];
                 
-                NSNumber *requestId = [[CTApiProxy sharedInstance] callApiWithRequest:request success:^(CTURLResponse *response) {
+                NSString *requestId = [[CTApiProxy sharedInstance] callApiWithRequest:request success:^(CTURLResponse *response) {
                     [self successedOnCallingAPI:response];
                 } fail:^(CTURLResponse *response) {
                     CTAPIManagerErrorType errorType = CTAPIManagerErrorTypeDefault;
@@ -178,7 +178,7 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
                 NSMutableDictionary *params = [reformedParams mutableCopy];
                 params[kCTAPIBaseManagerRequestID] = requestId;
                 [self afterCallingAPIWithParams:params];
-                return [requestId integerValue];
+                return requestId;
             
             } else {
                 [self failedOnCallingAPI:nil withErrorType:CTAPIManagerErrorTypeNoNetWork];
@@ -405,11 +405,11 @@ NSString * const kCTAPIBaseManagerRequestID = @"kCTAPIBaseManagerRequestID";
 }
 
 #pragma mark - private methods
-- (void)removeRequestIdWithRequestID:(NSInteger)requestId
+- (void)removeRequestIdWithRequestID:(NSString *)requestId
 {
-    NSNumber *requestIDToRemove = nil;
-    for (NSNumber *storedRequestId in self.requestIdList) {
-        if ([storedRequestId integerValue] == requestId) {
+    NSString *requestIDToRemove = nil;
+    for (NSString *storedRequestId in self.requestIdList) {
+        if ([storedRequestId isEqualToString:requestId]) {
             requestIDToRemove = storedRequestId;
         }
     }

--- a/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.h
+++ b/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.h
@@ -21,7 +21,7 @@ typedef NS_ENUM(NSUInteger, CTURLResponseStatus)
 @property (nonatomic, assign, readonly) CTURLResponseStatus status;
 @property (nonatomic, copy, readonly) NSString *contentString;
 @property (nonatomic, copy, readonly) id content;
-@property (nonatomic, assign, readonly) NSInteger requestId;
+@property (nonatomic, copy, readonly) NSString *requestId;
 @property (nonatomic, copy, readonly) NSURLRequest *request;
 @property (nonatomic, copy, readonly) NSData *responseData;
 @property (nonatomic, strong, readonly) NSString *errorMessage;
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, CTURLResponseStatus)
 
 @property (nonatomic, assign, readonly) BOOL isCache;
 
-- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSNumber *)requestId request:(NSURLRequest *)request responseObject:(id)responseObject error:(NSError *)error;
+- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSString *)requestId request:(NSURLRequest *)request responseObject:(id)responseObject error:(NSError *)error;
 
 // 使用initWithData的response，它的isCache是YES，上面两个函数生成的response的isCache是NO
 - (instancetype)initWithData:(NSData *)data;

--- a/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.m
+++ b/CTNetworking/CTNetworking/Components/URLResponse/CTURLResponse.m
@@ -16,7 +16,7 @@
 @property (nonatomic, copy, readwrite) NSString *contentString;
 @property (nonatomic, copy, readwrite) id content;
 @property (nonatomic, copy, readwrite) NSURLRequest *request;
-@property (nonatomic, assign, readwrite) NSInteger requestId;
+@property (nonatomic, copy, readwrite) NSString *requestId;
 @property (nonatomic, copy, readwrite) NSData *responseData;
 @property (nonatomic, assign, readwrite) BOOL isCache;
 @property (nonatomic, strong, readwrite) NSString *errorMessage;
@@ -26,12 +26,12 @@
 @implementation CTURLResponse
 
 #pragma mark - life cycle
-- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSNumber *)requestId request:(NSURLRequest *)request responseObject:(NSDictionary *)responseObject error:(NSError *)error
+- (instancetype)initWithResponseString:(NSString *)responseString requestId:(NSString *)requestId request:(NSURLRequest *)request responseObject:(NSDictionary *)responseObject error:(NSError *)error
 {
     self = [super init];
     if (self) {
         self.contentString = [responseString CT_defaultValue:@""];
-        self.requestId = [requestId integerValue];
+        self.requestId = requestId;
         self.request = request;
         self.acturlRequestParams = request.actualRequestParams;
         self.originRequestParams = request.originRequestParams;
@@ -49,7 +49,7 @@
     if (self) {
         self.contentString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
         self.status = [self responseStatusWithError:nil];
-        self.requestId = 0;
+        self.requestId = @"";
         self.request = nil;
         self.responseData = data;
         self.content = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingMutableContainers error:NULL];

--- a/CTNetworking/CTNetworking/Services/CTServiceFactory.m
+++ b/CTNetworking/CTNetworking/Services/CTServiceFactory.m
@@ -20,13 +20,13 @@
 @implementation CTServiceFactory
 
 #pragma mark - getters and setters
-- (NSMutableDictionary *)serviceStorage
-{
-    if (_serviceStorage == nil) {
-        _serviceStorage = [[NSMutableDictionary alloc] init];
-    }
-    return _serviceStorage;
-}
+//- (NSMutableDictionary *)serviceStorage
+//{
+//    if (_serviceStorage == nil) {
+//        _serviceStorage = [[NSMutableDictionary alloc] init];
+//    }
+//    return _serviceStorage;
+//}
 
 #pragma mark - life cycle
 + (instancetype)sharedInstance
@@ -39,12 +39,25 @@
     return sharedInstance;
 }
 
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        // 防止出现并发问题，不再使用懒加载方式初始化
+        _serviceStorage = [[NSMutableDictionary alloc] init];
+    }
+    
+    return self;
+}
+
 #pragma mark - public methods
 - (id <CTServiceProtocol>)serviceWithIdentifier:(NSString *)identifier
 {
-    if (self.serviceStorage[identifier] == nil) {
-        self.serviceStorage[identifier] = [self newServiceWithIdentifier:identifier];
+    @synchronized (self.serviceStorage) {
+        if (self.serviceStorage[identifier] == nil) {
+            self.serviceStorage[identifier] = [self newServiceWithIdentifier:identifier];
+        }
     }
+    
     return self.serviceStorage[identifier];
 }
 


### PR DESCRIPTION
这个PR我把loadDataWithParams实例方法放到了CTAPIBaseManager头文件中，变成了公共方法

原因：
项目中新新开发的restAPI接口有些参数放到了method中，例如
`  

- (NSString *)methodName {
    return [NSString stringWithFormat:@"moarestapi/im/chat/%@/user/undisturbedstatus", self.conversationId];
}   

`
需要在method中拼接一些参数，比如uid、conversationId之类的，这就导致这些API无法使用类方法的loadDataWithParams来发起请求，因为methodName方法是实例方法。只能通过实例方法loadData，通过代理回调的方式来处理响应，形成了一定的限制。所以我觉得可以开放loadDataWithParams实例方法，来方便使用。